### PR TITLE
Resolve race condition between opening modal and accessing offsetWidth/offsetHeight

### DIFF
--- a/resources/views/signature-pad.blade.php
+++ b/resources/views/signature-pad.blade.php
@@ -29,7 +29,7 @@
     @endphp
 
     <div
-        ax-load
+        ax-load="visible"
         ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('filament-autograph', 'saade/filament-autograph') }}"
         ax-load-css="{{ \Filament\Support\Facades\FilamentAsset::getStyleHref('filament-autograph-styles', 'saade/filament-autograph') }}"
         x-data="signaturePad({


### PR DESCRIPTION
When rendering the signature pad inside a modal, `offsetWidth` and `offsetHeight` will return `0` until the modal is open, meaning the canvas height and width are set to `0`, rendering it unusable.

Setting the alpine hook to `visible` will wait until the modal is open before initialising the component.

fixes #7