### PR TITLE
Add loadStrategy() option

### DIFF
--- a/resources/views/signature-pad.blade.php
+++ b/resources/views/signature-pad.blade.php
@@ -14,6 +14,7 @@
         $downloadActionDropdownPlacement = $getDownloadActionDropdownPlacement() ?? 'bottom-start';
         $isUndoable = $isUndoable();
         $isConfirmable = $isConfirmable();
+        $loadStrategy = $getLoadStrategy();
         
         $clearAction = $getAction('clear');
         $downloadAction = $getAction('download');
@@ -22,7 +23,7 @@
     @endphp
 
     <div
-        ax-load="visible"
+        ax-load="{{ $getLoadStrategy() }}"
         ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('filament-autograph', 'saade/filament-autograph') }}"
         ax-load-css="{{ \Filament\Support\Facades\FilamentAsset::getStyleHref('filament-autograph-styles', 'saade/filament-autograph') }}"
         x-data="signaturePad({

--- a/src/Forms/Components/Concerns/HasOptions.php
+++ b/src/Forms/Components/Concerns/HasOptions.php
@@ -32,6 +32,8 @@ trait HasOptions
 
     protected float | Closure $velocityFilterWeight = 0.7;
 
+    protected string | Closure $loadStrategy = 'visible';
+
     /**
      * Filename of the downloaded image. Without extension.
      */
@@ -167,6 +169,18 @@ trait HasOptions
         return $this;
     }
 
+    /**
+     * Strategy used to load the signature pad.
+     * If you notice that the signature pad is not loading correctly in modals, consider changing this value to "idle".
+     * See https://async-alpine.dev/docs/strategies/ for more details.
+     */
+    public function loadStrategy(string | Closure | null $loadStrategy): static
+    {
+        $this->loadStrategy = $loadStrategy;
+
+        return $this;
+    }
+
     public function getDotSize(): float
     {
         return $this->evaluate($this->dotSize);
@@ -225,5 +239,10 @@ trait HasOptions
     public function getVelocityFilterWeight(): float
     {
         return $this->evaluate($this->velocityFilterWeight);
+    }
+
+    public function getLoadStrategy(): string
+    {
+        return $this->evaluate($this->loadStrategy);
     }
 }


### PR DESCRIPTION
First of all, thank you for creating and maintaining this package!

In my use case, I found that the "idle" load strategy works more reliably than the default "visible" strategy, especially when handling modals on complex pages.

This PR introduces a `loadStrategy()` option, allowing users to customize the load strategy to suit their needs, rather than relying on the hardcoded default.

To ensure backward compatibility, the default strategy remains "visible", so no breaking changes are introduced.