### PR TITLE
fix: make load strategy configurable again

### DIFF
--- a/resources/lang/en/filament-autograph.php
+++ b/resources/lang/en/filament-autograph.php
@@ -17,11 +17,11 @@ return [
                 'png' => 'PNG',
                 'jpg' => 'JPG',
                 'svg' => 'SVG',
-            ]
+            ],
         ],
 
         'done' => [
             'label' => 'Done',
         ],
-    ]
+    ],
 ];

--- a/resources/lang/pt_BR/filament-autograph.php
+++ b/resources/lang/pt_BR/filament-autograph.php
@@ -17,11 +17,11 @@ return [
                 'png' => 'PNG',
                 'jpg' => 'JPG',
                 'svg' => 'SVG',
-            ]
+            ],
         ],
 
         'done' => [
             'label' => 'Concluir',
         ],
-    ]
+    ],
 ];

--- a/resources/views/signature-pad.blade.php
+++ b/resources/views/signature-pad.blade.php
@@ -24,7 +24,7 @@
     @endphp
 
     <div
-        x-load="visible || event (ax-modal-opened)"
+        x-load="{{ $loadStrategy }} || event (ax-modal-opened)"
         x-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('filament-autograph-alpine', 'saade/filament-autograph') }}"
         x-data="signaturePadFormComponent({
             backgroundColor: @js($getBackgroundColor()),

--- a/src/FilamentAutographServiceProvider.php
+++ b/src/FilamentAutographServiceProvider.php
@@ -46,7 +46,7 @@ class FilamentAutographServiceProvider extends PackageServiceProvider
     protected function getAssets(): array
     {
         return [
-            AlpineComponent::make('filament-autograph-alpine', __DIR__.'/../resources/dist/filament-autograph.js'),
+            AlpineComponent::make('filament-autograph-alpine', __DIR__ . '/../resources/dist/filament-autograph.js'),
         ];
     }
 }

--- a/src/Forms/Components/Concerns/HasActions.php
+++ b/src/Forms/Components/Concerns/HasActions.php
@@ -13,21 +13,21 @@ use Saade\FilamentAutograph\Forms\Components\Enums\DownloadableFormat;
 
 trait HasActions
 {
-    protected bool|Closure $isClearable = true;
+    protected bool | Closure $isClearable = true;
 
-    protected bool|Closure $isDownloadable = false;
+    protected bool | Closure $isDownloadable = false;
 
-    protected array|Closure $downloadableFormats = [
+    protected array | Closure $downloadableFormats = [
         DownloadableFormat::PNG,
         DownloadableFormat::JPG,
         DownloadableFormat::SVG,
     ];
 
-    protected string|Closure|null $downloadActionDropdownPlacement = null;
+    protected string | Closure | null $downloadActionDropdownPlacement = null;
 
-    protected bool|Closure $isUndoable = true;
+    protected bool | Closure $isUndoable = true;
 
-    protected bool|Closure $isConfirmable = false;
+    protected bool | Closure $isConfirmable = false;
 
     protected ?Closure $modifyClearActionUsing = null;
 
@@ -129,42 +129,42 @@ trait HasActions
         return $this;
     }
 
-    public function clearable(bool|Closure $condition = true): static
+    public function clearable(bool | Closure $condition = true): static
     {
         $this->isClearable = $condition;
 
         return $this;
     }
 
-    public function downloadable(bool|Closure $condition = true): static
+    public function downloadable(bool | Closure $condition = true): static
     {
         $this->isDownloadable = $condition;
 
         return $this;
     }
 
-    public function downloadableFormats(array|Closure $formats): static
+    public function downloadableFormats(array | Closure $formats): static
     {
         $this->downloadableFormats = $formats;
 
         return $this;
     }
 
-    public function downloadActionDropdownPlacement(string|Closure $placement): static
+    public function downloadActionDropdownPlacement(string | Closure $placement): static
     {
         $this->downloadActionDropdownPlacement = $placement;
 
         return $this;
     }
 
-    public function undoable(bool|Closure $condition = true): static
+    public function undoable(bool | Closure $condition = true): static
     {
         $this->isUndoable = $condition;
 
         return $this;
     }
 
-    public function confirmable(bool|Closure $condition = true, bool $shouldMakeComponentRequired = true): static
+    public function confirmable(bool | Closure $condition = true, bool $shouldMakeComponentRequired = true): static
     {
         $this->isConfirmable = $condition;
 

--- a/src/Forms/Components/SignaturePad.php
+++ b/src/Forms/Components/SignaturePad.php
@@ -2,7 +2,6 @@
 
 namespace Saade\FilamentAutograph\Forms\Components;
 
-use Closure;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Field;
 use Saade\FilamentAutograph\Forms\Components\Concerns\HasActions;


### PR DESCRIPTION
Default value is still "visible" so the default behaviour remains unchanged.
https://github.com/saade/filament-autograph/blob/4.x/src/Forms/Components/Concerns/HasOptions.php#L35